### PR TITLE
+10 Widget with local date-time in capital

### DIFF
--- a/src/components/CountryPage.tsx
+++ b/src/components/CountryPage.tsx
@@ -2,6 +2,7 @@ import { Container, Grid, Typography } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Gallery from 'Components/Gallery/Gallery';
 import Loader from 'Components/Loader';
+import DateTimeWidget from 'Components/DateTimeWidget';
 import { ICountry } from 'Entities/country';
 import { ID, Language } from 'Entities/travel-app';
 import React, { useEffect } from 'react';
@@ -65,7 +66,7 @@ const CountryPageContainer = (props: IProps): JSX.Element => {
                 курс валют
               </Grid>
               <Grid item sm={4}>
-                дата время
+                <DateTimeWidget />
               </Grid>
             </Grid>
           </Grid>

--- a/src/components/DateTimeWidget/DateTimeWidget.tsx
+++ b/src/components/DateTimeWidget/DateTimeWidget.tsx
@@ -1,0 +1,92 @@
+import { Typography, Box } from '@material-ui/core';
+import { withStyles, WithStyles } from '@material-ui/core/styles';
+import React, { useState, useEffect, useMemo } from 'react';
+import Loader from 'Components/Loader';
+import styles from './styles';
+
+interface Props extends WithStyles<typeof styles> {
+  timezone: string | undefined;
+  language: string;
+  isLoading: boolean;
+  error: Error | undefined;
+}
+
+const DateTimeWidget = ({
+  classes,
+  timezone,
+  language,
+  isLoading,
+  error,
+}: Props): JSX.Element => {
+  const [date, setDate] = useState<Date>(new Date());
+
+  useEffect(() => {
+    const timerId: number = window.setInterval(() => {
+      setDate(new Date());
+    }, 1000);
+    return () => clearInterval(timerId);
+  }, []);
+
+  const dateOptions: Intl.DateTimeFormatOptions = useMemo(() => {
+    return {
+      timeZone: timezone,
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    };
+  }, [timezone]);
+
+  const weekdayOptions: Intl.DateTimeFormatOptions = useMemo(() => {
+    return {
+      timeZone: timezone,
+      weekday: 'long',
+    };
+  }, [timezone]);
+
+  const timeOptions: Intl.DateTimeFormatOptions = useMemo(() => {
+    return {
+      timeZone: timezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    };
+  }, [timezone]);
+
+  const dateStr = date.toLocaleString(language, dateOptions);
+  const weekdayStr = date.toLocaleString(language, weekdayOptions);
+  const timeStr = date.toLocaleString(language, timeOptions);
+
+  if (error) {
+    return (
+      <Box className={classes.root}>
+        <Typography component="p" variant="body2">
+          No data
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Box className={classes.root}>
+        <Loader />
+      </Box>
+    );
+  }
+
+  return (
+    <Box className={classes.root}>
+      <Typography component="p" variant="body2">
+        {dateStr}
+      </Typography>
+      <Typography component="p" variant="body2">
+        {weekdayStr}
+      </Typography>
+      <Typography component="p" variant="body2">
+        {timeStr}
+      </Typography>
+    </Box>
+  );
+};
+
+export default withStyles(styles, { withTheme: true })(DateTimeWidget);

--- a/src/components/DateTimeWidget/DateTimeWidget.tsx
+++ b/src/components/DateTimeWidget/DateTimeWidget.tsx
@@ -1,23 +1,18 @@
-import { Typography, Box } from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
 import { withStyles, WithStyles } from '@material-ui/core/styles';
-import React, { useState, useEffect, useMemo } from 'react';
 import Loader from 'Components/Loader';
+import React, { useEffect, useMemo, useState } from 'react';
 import styles from './styles';
 
 interface Props extends WithStyles<typeof styles> {
-  timezone: string | undefined;
-  language: string;
-  isLoading: boolean;
   error: Error | undefined;
+  isLoading: boolean;
+  language: string;
+  timeZone: string;
 }
 
-const DateTimeWidget = ({
-  classes,
-  timezone,
-  language,
-  isLoading,
-  error,
-}: Props): JSX.Element => {
+const DateTimeWidget = (props: Props): JSX.Element => {
+  const { classes, timeZone, language, isLoading, error } = props;
   const [date, setDate] = useState<Date>(new Date());
 
   useEffect(() => {
@@ -27,30 +22,33 @@ const DateTimeWidget = ({
     return () => clearInterval(timerId);
   }, []);
 
-  const dateOptions: Intl.DateTimeFormatOptions = useMemo(() => {
-    return {
-      timeZone: timezone,
-      year: 'numeric',
-      month: 'long',
+  const dateOptions: Intl.DateTimeFormatOptions = useMemo(
+    () => ({
       day: 'numeric',
-    };
-  }, [timezone]);
+      month: 'long',
+      year: 'numeric',
+      timeZone,
+    }),
+    [timeZone]
+  );
 
-  const weekdayOptions: Intl.DateTimeFormatOptions = useMemo(() => {
-    return {
-      timeZone: timezone,
+  const weekdayOptions: Intl.DateTimeFormatOptions = useMemo(
+    () => ({
       weekday: 'long',
-    };
-  }, [timezone]);
+      timeZone,
+    }),
+    [timeZone]
+  );
 
-  const timeOptions: Intl.DateTimeFormatOptions = useMemo(() => {
-    return {
-      timeZone: timezone,
+  const timeOptions: Intl.DateTimeFormatOptions = useMemo(
+    () => ({
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-    };
-  }, [timezone]);
+      timeZone,
+    }),
+    [timeZone]
+  );
 
   const dateStr = date.toLocaleString(language, dateOptions);
   const weekdayStr = date.toLocaleString(language, weekdayOptions);

--- a/src/components/DateTimeWidget/DateTimeWidgetContainer.ts
+++ b/src/components/DateTimeWidget/DateTimeWidgetContainer.ts
@@ -3,10 +3,12 @@ import * as StateTypes from 'States/types';
 import DateTimeWidget from './DateTimeWidget';
 
 const mapStateToProps = (state: StateTypes.RootState) => ({
-  language: state.languageSelector.language,
-  timezone: state.country && state.country.country && state.country.country.timezone,
-  isLoading: state.country.isLoading,
   error: state.country.error,
+  isLoading: state.country.isLoading,
+  language: state.languageSelector.language,
+  timeZone: state.country.country
+    ? state.country.country.timezone
+    : Intl.DateTimeFormat().resolvedOptions().timeZone,
 });
 
 export default connect(mapStateToProps)(DateTimeWidget);

--- a/src/components/DateTimeWidget/DateTimeWidgetContainer.ts
+++ b/src/components/DateTimeWidget/DateTimeWidgetContainer.ts
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+import * as StateTypes from 'States/types';
+import DateTimeWidget from './DateTimeWidget';
+
+const mapStateToProps = (state: StateTypes.RootState) => ({
+  language: state.languageSelector.language,
+  timezone: state.country && state.country.country && state.country.country.timezone,
+  isLoading: state.country.isLoading,
+  error: state.country.error,
+});
+
+export default connect(mapStateToProps)(DateTimeWidget);

--- a/src/components/DateTimeWidget/index.ts
+++ b/src/components/DateTimeWidget/index.ts
@@ -1,0 +1,3 @@
+import DateTimeWidget from './DateTimeWidgetContainer';
+
+export default DateTimeWidget;

--- a/src/components/DateTimeWidget/styles.ts
+++ b/src/components/DateTimeWidget/styles.ts
@@ -1,0 +1,11 @@
+import { createStyles, Theme } from '@material-ui/core/styles';
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      maxWidth: theme.spacing(60),
+    },
+  });
+
+export default styles;

--- a/src/entities/country.ts
+++ b/src/entities/country.ts
@@ -5,6 +5,10 @@ export interface ICountryPreview {
   name: string;
   capital: string;
   photoUrl: string;
+  timezone: string;
+  currency: string;
+  lat: number;
+  lng: number;
 }
 
 export interface IRating {


### PR DESCRIPTION
## +10 Widget with local date-time in capital

![Screenshot from 2021-03-14 18-26-39](https://user-images.githubusercontent.com/5857672/111074269-48e7c400-84f3-11eb-9dc7-3fe858a05412.png)

- [x] Число
- [x] Название месяца
- [x] Название дня недели
- [x] Время HH-MM-SS

### Требования реализации:

- [x] использовать встроенные возможности JS:
  - [x] для получения локального времени
  - [x] для локализации отображаемой даты
- [x] должные переводится на текущий язык сайта

### Примечание
- Стили пока отсутствуют.
- компонент отслеживает isLoading и error  (т.к. он находится в компоненте CountryPage, который сам их отслеживает, то можно было бы это опустить), предлагаю оставить, чтобы компонент был самодостаточным