### PR TITLE
Drawer with widgets

### DIFF
--- a/src/components/CountryPage.tsx
+++ b/src/components/CountryPage.tsx
@@ -2,8 +2,7 @@ import { Container, Grid, Typography } from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Gallery from 'Components/Gallery/Gallery';
 import Loader from 'Components/Loader';
-import DateTimeWidget from 'Components/DateTimeWidget';
-import WeatherWidget from 'Components/WeatherWidget';
+import WidgetsPanel from 'Components/WidgetsPanel';
 import { ICountry } from 'Entities/country';
 import { ID, Language } from 'Entities/travel-app';
 import React, { useEffect } from 'react';
@@ -59,17 +58,6 @@ const CountryPageContainer = (props: IProps): JSX.Element => {
                 {country.capital}
               </Typography>
             </Grid>
-            <Grid className={classes.widgetsContainer} container>
-              <Grid item sm={4}>
-                <WeatherWidget />
-              </Grid>
-              <Grid item sm={4}>
-                курс валют
-              </Grid>
-              <Grid item sm={4}>
-                <DateTimeWidget />
-              </Grid>
-            </Grid>
           </Grid>
         </Grid>
 
@@ -84,6 +72,7 @@ const CountryPageContainer = (props: IProps): JSX.Element => {
         <Gallery sights={country.sights} />
         <div>video</div>
       </Grid>
+      <WidgetsPanel />
     </Container>
   ) : (
     <Loader />
@@ -93,6 +82,8 @@ const CountryPageContainer = (props: IProps): JSX.Element => {
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     main: {
+      position: 'relative',
+      display: 'flex',
       flexBasis: 'auto',
       flexGrow: 1,
       flexShrink: 0,
@@ -112,7 +103,6 @@ const useStyles = makeStyles((theme: Theme) =>
     countryCapital: {
       fontSize: '3rem',
     },
-    widgetsContainer: {},
   })
 );
 

--- a/src/components/WidgetsPanel/WidgetsPanel.tsx
+++ b/src/components/WidgetsPanel/WidgetsPanel.tsx
@@ -1,0 +1,63 @@
+import { Divider, Drawer, Hidden, IconButton } from '@material-ui/core';
+import { withStyles, WithStyles } from '@material-ui/core/styles';
+import WidgetsIcon from '@material-ui/icons/Widgets';
+import DateTimeWidget from 'Components/DateTimeWidget';
+import WeatherWidget from 'Components/WeatherWidget';
+import * as React from 'react';
+import { useState } from 'react';
+import styles from './styles';
+
+const WidgetsPanel = ({ classes }: WithStyles): JSX.Element => {
+  const [mobileOpen, setMobileOpen] = useState<boolean>(false);
+
+  const handleDrawerToggle = (): void => {
+    setMobileOpen((s) => !s);
+  };
+
+  const Widgets = (
+    <>
+      <WeatherWidget />
+      <Divider />
+      курс валют
+      <Divider />
+      <DateTimeWidget />
+    </>
+  );
+
+  return (
+    <>
+      <IconButton
+        aria-label="open widgets panel"
+        className={classes.menuButton}
+        color="inherit"
+        edge="start"
+        onClick={handleDrawerToggle}
+      >
+        <WidgetsIcon />
+      </IconButton>
+
+      <aside aria-label="widgets" className={classes.drawer}>
+        <Hidden implementation="css" smUp>
+          <Drawer
+            ModalProps={{ keepMounted: true }}
+            anchor="right"
+            classes={{ paper: classes.drawerPaper }}
+            onClose={handleDrawerToggle}
+            open={mobileOpen}
+            variant="temporary"
+          >
+            {Widgets}
+          </Drawer>
+        </Hidden>
+
+        <Hidden implementation="css" smDown>
+          <Drawer classes={{ paper: classes.drawerPaper }} open variant="permanent">
+            {Widgets}
+          </Drawer>
+        </Hidden>
+      </aside>
+    </>
+  );
+};
+
+export default withStyles(styles, { withTheme: true })(WidgetsPanel);

--- a/src/components/WidgetsPanel/index.ts
+++ b/src/components/WidgetsPanel/index.ts
@@ -1,0 +1,3 @@
+import WidgetsPanel from './WidgetsPanel';
+
+export default WidgetsPanel;

--- a/src/components/WidgetsPanel/styles.ts
+++ b/src/components/WidgetsPanel/styles.ts
@@ -1,0 +1,32 @@
+import { createStyles, Theme } from '@material-ui/core/styles';
+
+const drawerWidth = 200;
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+const styles = (theme: Theme) =>
+  createStyles({
+    drawer: {
+      [theme.breakpoints.up('sm')]: {
+        position: 'relative',
+        width: drawerWidth,
+        flexShrink: 0,
+      },
+    },
+    menuButton: {
+      position: 'absolute',
+      right: 0,
+      top: theme.spacing(2),
+      [theme.breakpoints.up('sm')]: {
+        display: 'none',
+      },
+    },
+    drawerPaper: {
+      width: drawerWidth,
+      [theme.breakpoints.up('sm')]: {
+        position: 'relative',
+        flexShrink: 0,
+      },
+    },
+  });
+
+export default styles;


### PR DESCRIPTION
## Drawer with widgets

- [X] - в CoutryPage добавлена aside на основе drawer material ui
- [ ] - стили

### Примечание:
- стилизовать компонент можно вместе с окончательной стилизацией CoutryPage
- не смог разобраться с одним нюансом: на определенных брекпоинтах (где то с мобилки и до 1000рх) ширина компонента почему то не выдерживается и он не отображается на экране. Может кто то более опытный в использовании material ui сможет разобраться
- после добавления в основную ветку всех компонентов виджетов, нужно будет их перенести в этот компонент из CoutryPage